### PR TITLE
Reformat all PHP files to be PSR-2 and PSR-4 compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v1.1.0]
+This version is compatible with [SimpleSAMLphp v1.17](https://simplesamlphp.org/docs/1.17/simplesamlphp-changelog)
+
+### Changed
+- Code reformatted to PSR-2
+- Declare module's class under SimpleSAML\Module namespace
+
+## [v1.0.0]
+This version is compatible with [SimpleSAMLphp v1.14](https://simplesamlphp.org/docs/1.14/simplesamlphp-changelog)
+
+### Added
+- Client class
+  - Retrieves attributes from the GOCDB and adds them to the list of attributes received from the identity provider

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ The following configuration options are available:
     ],
 ```
 
+## Compatibility matrix
+This table matches the module version with the supported SimpleSAMLphp version.
+| Module |  SimpleSAMLphp |
+|:------:|:--------------:|
+| v1.0.0 | v1.14          |
+| v1.1.0 | v1.17          |
+
 # License
 
 Licensed under the Apache 2.0 license, for details see `LICENSE`.

--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ The following configuration options are available:
 ### Example configuration
 
 ```
-'authproc' => array(
+'authproc' => [
     ...
-    '60' => array(
+    '60' => [
          'class' => 'attrauthgocdb:Client',
          'api_base_path' => 'https://gocdb.aa.org/api',
-         'subject_attributes' => array(
+         'subject_attributes' => [
              'distinguishedName',
-         ),
+         ],
          'role_attribute' => 'eduPersonEntitlement',
          'role_urn_namespace' => 'urn:mace:aa.org',
          'role_scope' => 'vo.org',
          'ssl_client_cert' => 'client_example_org.chained.pem',
          'ssl_verify_peer' => true,
-    ),
+    ],
 ```
 
 # License

--- a/lib/Auth/Process/Client.php
+++ b/lib/Auth/Process/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace SimpleSAML\Module\attrauthgocdb\Auth\Process;
+
 /**
  * Authproc filter for retrieving attributes from the Grid Configuration 
  * Database (GOCDB) and adding them to the list of attributes received from the
@@ -24,7 +26,7 @@
  *
  * @author Nicolas Liampotis <nliam@grnet.gr>
  */
-class sspmod_attrauthgocdb_Auth_Process_Client extends SimpleSAML_Auth_ProcessingFilter
+class Client extends \SimpleSAML\Auth\ProcessingFilter
 {
     // Set default configuration options
     private $config = array(

--- a/lib/Auth/Process/Client.php
+++ b/lib/Auth/Process/Client.php
@@ -15,39 +15,39 @@ use \SimpleSAML\XHTML\Template;
  *
  * Example configuration:
  *
- *    'authproc' => array(
+ *    'authproc' => [
  *       ...
- *       '60' => array(
+ *       '60' => [
  *            'class' => 'attrauthgocdb:Client',
  *            'api_base_path' => 'https://gocdb.aa.org/api',
- *            'subject_attributes' => array(
+ *            'subject_attributes' => [
  *                'distinguishedName',
- *            ),
+ *            ],
  *            'role_attribute' => 'eduPersonEntitlement',
  *            'role_urn_namespace' => 'urn:mace:aa.org',
  *            'role_scope' => 'vo.org',
  *            'ssl_client_cert' => 'client_example_org.chained.pem',
  *            'ssl_verify_peer' => true,
- *       ),
+ *       ],
  *
  * @author Nicolas Liampotis <nliam@grnet.gr>
  */
 class Client extends \SimpleSAML\Auth\ProcessingFilter
 {
     // Set default configuration options
-    private $config = array(
+    private $config = [
         'ssl_verify_peer' => true,
-    );
+    ];
 
     public function __construct($config, $reserved)
     {
         parent::__construct($config, $reserved);
-        $params = array(
+        $params = [
             'api_base_path',
             'subject_attributes',
             'role_attribute',
             'role_urn_namespace',
-        );
+        ];
         foreach ($params as $param) {
             if (!array_key_exists($param, $config)) {
                 throw new Exception(
@@ -56,11 +56,11 @@ class Client extends \SimpleSAML\Auth\ProcessingFilter
             }
             $this->config[$param] = $config[$param];
         }
-        $optionalParams = array(
+        $optionalParams = [
             'role_scope',
             'ssl_client_cert',
             'ssl_verify_peer',
-        );
+        ];
         foreach ($optionalParams as $optionalParam) {
             if (array_key_exists($optionalParam, $config)) {
                 $this->config[$optionalParam] = $config[$optionalParam];
@@ -72,7 +72,7 @@ class Client extends \SimpleSAML\Auth\ProcessingFilter
     {
         try {
             assert('is_array($state)');
-            $subjectIds = array();
+            $subjectIds = [];
             foreach ($this->config['subject_attributes'] as $subjectAttribute) {
                 if (!empty($state['Attributes'][$subjectAttribute])) {
                     $subjectIds = array_merge(
@@ -103,7 +103,7 @@ class Client extends \SimpleSAML\Auth\ProcessingFilter
                 }
                 if (!empty($newAttributes)) {
                     if (!isset($state['Attributes'][$this->config['role_attribute']])) {
-                        $state['Attributes'][$this->config['role_attribute']] = array();
+                        $state['Attributes'][$this->config['role_attribute']] = [];
                     }
                     $state['Attributes'][$this->config['role_attribute']] = array_merge(
                         $state['Attributes'][$this->config['role_attribute']],
@@ -125,7 +125,7 @@ class Client extends \SimpleSAML\Auth\ProcessingFilter
         Logger::debug('[attrauthgocdb] getAttributes: subjectId='
             . var_export($subjectId, true));
 
-        $attributes = array();
+        $attributes = [];
 
         // Construct GOCDB API URL
         $url = $this->config['api_base_path'] . '/?method=get_user&dn='
@@ -133,7 +133,7 @@ class Client extends \SimpleSAML\Auth\ProcessingFilter
         $data = $this->http('GET', $url);
         while ($data->count() >= 1 && !empty($data->{'EGEE_USER'}->{'USER_ROLE'})) {
             if (!array_key_exists($this->config['role_attribute'], $attributes)) {
-                $attributes[$this->config['role_attribute']] = array();
+                $attributes[$this->config['role_attribute']] = [];
             }
             foreach ($data->{'EGEE_USER'}->{'USER_ROLE'} as $userRole) {
                 $value = $this->config['role_urn_namespace']
@@ -166,12 +166,12 @@ class Client extends \SimpleSAML\Auth\ProcessingFilter
         $ch = curl_init($url);
         curl_setopt_array(
             $ch,
-            array(
+            [
                 CURLOPT_CUSTOMREQUEST => $method,
                 CURLOPT_RETURNTRANSFER => true,
                 CURLOPT_SSL_VERIFYPEER => $this->config['ssl_verify_peer'],
                 CURLOPT_CONNECTTIMEOUT => 8,
-            )
+            ]
         );
         if (!empty($this->config['ssl_client_cert'])) {
             curl_setopt(
@@ -200,10 +200,10 @@ class Client extends \SimpleSAML\Auth\ProcessingFilter
         Logger::debug("[attrauthgocdb] getPageMeta: response="
             . var_export($response, true));
         if (empty($response->{'meta'})) {
-            return array();
+            return [];
         }
         $meta = $response->{'meta'};
-        $result = array();
+        $result = [];
         if (!empty($meta->{'count'})) {
             $result['count'] = (int)$meta->{'count'}->__toString();
         }

--- a/lib/Auth/Process/Client.php
+++ b/lib/Auth/Process/Client.php
@@ -56,14 +56,14 @@ class Client extends \SimpleSAML\Auth\ProcessingFilter
             }
             $this->config[$param] = $config[$param];
         }
-        $optional_params = array(
+        $optionalParams = array(
             'role_scope',
             'ssl_client_cert',
             'ssl_verify_peer',
         );
-        foreach ($optional_params as $optional_param) {
-            if (array_key_exists($optional_param, $config)) {
-                $this->config[$optional_param] = $config[$optional_param];
+        foreach ($optionalParams as $optionalParam) {
+            if (array_key_exists($optionalParam, $config)) {
+                $this->config[$optionalParam] = $config[$optionalParam];
             }
         }
     }
@@ -135,11 +135,11 @@ class Client extends \SimpleSAML\Auth\ProcessingFilter
             if (!array_key_exists($this->config['role_attribute'], $attributes)) {
                 $attributes[$this->config['role_attribute']] = array();
             }
-            foreach ($data->{'EGEE_USER'}->{'USER_ROLE'} as $user_role) {
+            foreach ($data->{'EGEE_USER'}->{'USER_ROLE'} as $userRole) {
                 $value = $this->config['role_urn_namespace']
-                    . ':' . urlencode($user_role->{'PRIMARY_KEY'})
-                    . ':' . urlencode($user_role->{'ON_ENTITY'})
-                    . ':' . urlencode($user_role->{'USER_ROLE'});
+                    . ':' . urlencode($userRole->{'PRIMARY_KEY'})
+                    . ':' . urlencode($userRole->{'ON_ENTITY'})
+                    . ':' . urlencode($userRole->{'USER_ROLE'});
                 if (isset($this->config['role_scope'])) {
                     $value .= '@' . $this->config['role_scope'];
                 }
@@ -183,12 +183,12 @@ class Client extends \SimpleSAML\Auth\ProcessingFilter
 
         // Send the request
         $response = curl_exec($ch);
-        $http_response = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $httpResponse = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
         // Check for error; not even redirects are allowed here
-        if ($http_response !== 200) {
+        if ($httpResponse !== 200) {
             Logger::error("[attrauthgocdb] API request failed: HTTP response code: "
-                . $http_response . ", error message: '" . curl_error($ch)) . "'";
+                . $httpResponse . ", error message: '" . curl_error($ch)) . "'";
             throw new Exception("API request failed");
         }
         $data = new SimpleXMLElement($response);

--- a/templates/exception.tpl.php
+++ b/templates/exception.tpl.php
@@ -9,7 +9,7 @@ An unexpected error occurred while retrieving attributes from an external attrib
 <pre>
 
 <?php
-    echo $this->data['e'];
+echo $this->data['e'];
 ?>
 </pre>
 


### PR DESCRIPTION
- Switch class to use namespaces
- Add use declarations to all 
- Change coding style based on PSR-2
  - Remove whitespaces
  - Fix code allignment
- Change coding style based on PSR-1
  - Switch variable names to camelCase
- Apply modern array syntax to all files
